### PR TITLE
Problem: Uses old version of Google SDK

### DIFF
--- a/ewok.yml
+++ b/ewok.yml
@@ -11,11 +11,9 @@ build:
         - script:
             name: config
             code: |
-                GCLOUD_VERSION="127.0.0-linux-x86_64"
+                GCLOUD_VERSION="151.0.0-linux-x86_64"
                 export GCLOUD_DIRNAME="google-cloud-sdk"
-                export KUBERNETES_VERSION="1.6.0"
-                export KUBERNETES_SHA256="c488d77cd980ca7dae03bc684e19bd6a329962e32ed7a1bc9c4d560ed433399a"
-                export GCLOUD_SHA="45abe78986b0ff9a147904aaf20d552fa4ad6f29"
+                export GCLOUD_SHA="53caea9133e3ed0efe26164e8a29751a3caf770f"
                 export GCLOUD_FILENAME="${GCLOUD_DIRNAME}-${GCLOUD_VERSION}.tar.gz"
                 export GCLOUD_URL="https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/${GCLOUD_FILENAME}"
                 export UPX_VERSION="3.93"
@@ -38,16 +36,6 @@ build:
             name: Extract upx archive
             code: |
                 tar -xf ${UPX_FILENAME}
-
-        - script:
-            name: fetch kubernetes archive
-            code: |
-                curl -L https://storage.googleapis.com/kubernetes-release/release/v${KUBERNETES_VERSION}/bin/linux/amd64/kubectl > $WERCKER_OUTPUT_DIR/kubectl
-
-        - script:
-            name: validate kubernetes archive
-            code: |
-                cat $WERCKER_OUTPUT_DIR/kubectl| sha256sum | grep -q "$KUBERNETES_SHA256"
 
         - script:
             name: Fetch gcloud archive
@@ -78,13 +66,21 @@ build:
             name: prepare output
             code: |
                 cp  "${WERCKER_ROOT}/LICENSE" "${WERCKER_ROOT}/README.md" "${WERCKER_ROOT}/run.sh" "${WERCKER_ROOT}/wercker.yml" "${WERCKER_ROOT}/wercker-step.yml" "$WERCKER_OUTPUT_DIR"
+                cd $WERCKER_OUTPUT_DIR
                 chmod ugo+rx "$WERCKER_OUTPUT_DIR/${GCLOUD_DIRNAME}/bin/gcloud"
-                chmod ugo+rx "$WERCKER_OUTPUT_DIR/kubectl"
+                rm -rf "${GCLOUD_DIRNAME}/platform/gsutil"
+                ln -sf ${GCLOUD_DIRNAME}/bin/kubectl kubectl
 
         - script:
             name: Compress kubectl
             code: |
-                ${UPX_DIRNAME}/upx $WERCKER_OUTPUT_DIR/kubectl
+                ${UPX_DIRNAME}/upx -1 "$WERCKER_OUTPUT_DIR/${GCLOUD_DIRNAME}/bin/kubectl"
+
+        - script:
+            name: Measure output folder
+            code: |
+                du -csh $WERCKER_OUTPUT_DIR/*
+                du -csh $WERCKER_OUTPUT_DIR/${GCLOUD_DIRNAME}/*
 
 test-busybox:
     box:

--- a/wercker.yml
+++ b/wercker.yml
@@ -6,11 +6,9 @@ build:
         - script:
             name: config
             code: |
-                GCLOUD_VERSION="127.0.0-linux-x86_64"
+                GCLOUD_VERSION="151.0.0-linux-x86_64"
                 export GCLOUD_DIRNAME="google-cloud-sdk"
-                export KUBERNETES_VERSION="1.6.0"
-                export KUBERNETES_SHA256="c488d77cd980ca7dae03bc684e19bd6a329962e32ed7a1bc9c4d560ed433399a"
-                export GCLOUD_SHA="45abe78986b0ff9a147904aaf20d552fa4ad6f29"
+                export GCLOUD_SHA="53caea9133e3ed0efe26164e8a29751a3caf770f"
                 export GCLOUD_FILENAME="${GCLOUD_DIRNAME}-${GCLOUD_VERSION}.tar.gz"
                 export GCLOUD_URL="https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/${GCLOUD_FILENAME}"
                 export UPX_VERSION="3.93"
@@ -33,16 +31,6 @@ build:
             name: Extract upx archive
             code: |
                 tar -xf ${UPX_FILENAME}
-
-        - script:
-            name: fetch kubernetes archive
-            code: |
-                curl -L https://storage.googleapis.com/kubernetes-release/release/v${KUBERNETES_VERSION}/bin/linux/amd64/kubectl > $WERCKER_OUTPUT_DIR/kubectl
-
-        - script:
-            name: validate kubernetes archive
-            code: |
-                cat $WERCKER_OUTPUT_DIR/kubectl| sha256sum | grep -q "$KUBERNETES_SHA256"
 
         - script:
             name: Fetch gcloud archive
@@ -73,11 +61,19 @@ build:
             name: prepare output
             code: |
                 cp  "${WERCKER_ROOT}/LICENSE" "${WERCKER_ROOT}/README.md" "${WERCKER_ROOT}/run.sh" "${WERCKER_ROOT}/wercker.yml" "${WERCKER_ROOT}/wercker-step.yml" "$WERCKER_OUTPUT_DIR"
+                cd $WERCKER_OUTPUT_DIR
                 chmod ugo+rx "$WERCKER_OUTPUT_DIR/${GCLOUD_DIRNAME}/bin/gcloud"
-                chmod ugo+rx "$WERCKER_OUTPUT_DIR/kubectl"
+                rm -rf "${GCLOUD_DIRNAME}/platform/gsutil"
+                rm -rf "${GCLOUD_DIRNAME}/platform/bq"
+                ln -sf ${GCLOUD_DIRNAME}/bin/kubectl kubectl
 
         - script:
             name: Compress kubectl
             code: |
-                ${UPX_DIRNAME}/upx $WERCKER_OUTPUT_DIR/kubectl
+                ${UPX_DIRNAME}/upx "$WERCKER_OUTPUT_DIR/${GCLOUD_DIRNAME}/bin/kubectl"
 
+        - script:
+            name: Measure output folder
+            code: |
+                du -csh $WERCKER_OUTPUT_DIR/*
+                du -csh $WERCKER_OUTPUT_DIR/${GCLOUD_DIRNAME}/*


### PR DESCRIPTION
This step uses version 120 but the current
version is 151. The old version contains
among other things outdated versions of
kubectl.

Solution: Update to version 151.

Updating to 151 causes the tarball to
grow past 50MB which means wercker refuses
to deploy it as a step as the maximum
size allowed is 50MB.

To reduce the size of the step the following
was done:

* Duplicate kubectl removed, and symlink to
the gcloud one used instead;
* gsutil and bq removed from platform/ as they
are not required;
* UPX used to compress the kubectl binary